### PR TITLE
Plans API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install terraform-cloud # With NPM
 import { TerraformCloud } from 'terraform-cloud'
 
 // Set a your terraform cloud API token
-const { Account } = new TerraformCloud('terraform-api-token')
+const { Account, Plans } = new TerraformCloud('terraform-api-token')
 
 // Make an API call
 
@@ -47,16 +47,20 @@ const updatePasswordRequest = {
 Account.updatePassword(updatePasswordRequest).then(user => {
   // handle account password update
 })
+
+Plans.show('plan-id').then(plan => {
+  // handle plan data
+})
 ```
 
 ## Current implementation
 
 - [x] [Account](https://www.terraform.io/docs/cloud/api/account.html) (100%)
+- [x] [Plans](https://www.terraform.io/docs/cloud/api/plans.html) (90%) - **TODO:** Plan Json Output
 
 ## TODO
 
 - [ ] Runs
-- [ ] Plans
 - [ ] Workspaces
 - [ ] ...
 

--- a/src/api/Plans.ts
+++ b/src/api/Plans.ts
@@ -11,9 +11,4 @@ export default class Plans extends Request {
     const path = `/plans/${planId}`
     return await this.get<Plan>(path)
   }
-
-  async jsonOutput(planId: string): Promise<unknown> {
-    const path = `/plans/${planId}/json-output`
-    return await this.get(path)
-  }
 }

--- a/src/api/Plans.ts
+++ b/src/api/Plans.ts
@@ -1,0 +1,19 @@
+import { AxiosInstance } from 'axios'
+import { Plan } from '../types'
+import { Request } from './Request'
+
+export default class Plans extends Request {
+  constructor(client: AxiosInstance) {
+    super(client)
+  }
+
+  async show(planId: string): Promise<Plan> {
+    const path = `/plans/${planId}`
+    return await this.get<Plan>(path)
+  }
+
+  async jsonOutput(planId: string): Promise<unknown> {
+    const path = `/plans/${planId}/json-output`
+    return await this.get(path)
+  }
+}

--- a/src/api/TerraformCloud.ts
+++ b/src/api/TerraformCloud.ts
@@ -1,13 +1,16 @@
 import { EventEmitter } from 'events'
 import terraformCloudApiClient from './terraformCloudApiClient'
 import Account from './Account'
+import Plans from './Plans'
 
 export default class TerraformCloud extends EventEmitter {
   public Account: Account
+  public Plans: Plans
 
   constructor(apiKey: string) {
     super()
     const client = terraformCloudApiClient(apiKey)
     this.Account = new Account(client)
+    this.Plans = new Plans(client)
   }
 }

--- a/src/types/Plan.ts
+++ b/src/types/Plan.ts
@@ -14,7 +14,7 @@ interface PlanAttributes {
   resourceAdditions: number
   resourceChanges: number
   resourceDestructions: number
-  status: string
+  status: 'pending' | 'managed_queued' | 'queued' | 'running' | 'errored' | 'canceled' | 'finished' | 'unreachable'
   statusTimestamps: PlanTimestamps
 }
 

--- a/src/types/TerraformCloudData.ts
+++ b/src/types/TerraformCloudData.ts
@@ -6,6 +6,7 @@ interface Data {
 export interface Links {
   self?: string
   related?: string
+  jsonOutput?: string
 }
 
 export type Relationship = {

--- a/test/api/Plans.spec.ts
+++ b/test/api/Plans.spec.ts
@@ -1,0 +1,17 @@
+import nock from 'nock'
+import TerraformCloud from '../../src/api/TerraformCloud'
+import { PlanMock } from '../mocks'
+
+const { Plans } = new TerraformCloud('api-key')
+const planId = 'plan-id'
+
+describe('Plans endpoints', () => {
+  it('return a plan by id', async done => {
+    const scope = nock('https://app.terraform.io/api/v2').get(`/plans/${planId}`).reply(200, PlanMock)
+    const plan = await Plans.show(planId)
+    expect(plan.id).toBe(planId)
+    expect(plan.attributes.status).toBe('finished')
+    scope.done()
+    done()
+  })
+})

--- a/test/mocks/PlanMock.ts
+++ b/test/mocks/PlanMock.ts
@@ -1,0 +1,30 @@
+export const PlanMock = {
+  data: {
+    id: 'plan-id',
+    type: 'plans',
+    attributes: {
+      'has-changes': true,
+      'resource-additions': 0,
+      'resource-changes': 1,
+      'resource-destructions': 0,
+      status: 'finished',
+      'status-timestamps': {
+        'queued-at': '2018-07-02T22:29:53+00:00',
+        'pending-at': '2018-07-02T22:29:53+00:00',
+        'started-at': '2018-07-02T22:29:54+00:00',
+        'finished-at': '2018-07-02T22:29:58+00:00',
+      },
+      'log-read-url':
+        'https://archivist.terraform.io/v1/object/dmF1bHQ6djE6OFA1eEdlSFVHRSs4YUcwaW83a1dRRDA0U2E3T3FiWk1HM2NyQlNtcS9JS1hHN3dmTXJmaFhEYTlHdTF1ZlgxZ2wzVC9kVTlNcjRPOEJkK050VFI3U3dvS2ZuaUhFSGpVenJVUFYzSFVZQ1VZYno3T3UyYjdDRVRPRE5pbWJDVTIrNllQTENyTndYd1Y0ak1DL1dPVlN1VlNxKzYzbWlIcnJPa2dRRkJZZGtFeTNiaU84YlZ4QWs2QzlLY3VJb3lmWlIrajF4a1hYZTlsWnFYemRkL2pNOG9Zc0ZDakdVMCtURUE3dDNMODRsRnY4cWl1dUN5dUVuUzdnZzFwL3BNeHlwbXNXZWRrUDhXdzhGNnF4c3dqaXlZS29oL3FKakI5dm9uYU5ZKzAybnloREdnQ3J2Rk5WMlBJemZQTg',
+    },
+    relationships: {
+      'state-versions': {
+        data: [],
+      },
+    },
+    links: {
+      self: '/api/v2/plans/plan-id',
+      'json-output': '/api/v2/plans/plan-id/json-output',
+    },
+  },
+}

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -1,3 +1,4 @@
 import { UserDetailsUpdateMock, UserMock, UserPasswordUpdateMock } from './UserMock'
+import { PlanMock } from './PlanMock'
 
-export { UserDetailsUpdateMock, UserMock, UserPasswordUpdateMock }
+export { PlanMock, UserDetailsUpdateMock, UserMock, UserPasswordUpdateMock }


### PR DESCRIPTION
### What? Why? 🎩

Add Terraform Cloud Plan API endpoints

- [x] Show plan

#### Note 📓

The API endpoint to get the plan JSON Output needs an special handler to redirect the user to the temporally download URL. This is a 307 HTTP code with a direct download as it is specified here 👉🏽  [[Retrieve JSON Execution Plan]](https://www.terraform.io/docs/cloud/api/plans.html#retrieve-the-json-execution-plan).

We should track that on a new issue.

