### PR TITLE
refactor: change folder structure and type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install terraform-cloud # With NPM
 import { TerraformCloud } from 'terraform-cloud'
 
 // Set a your terraform cloud API token
-const { Account, Plans } = new TerraformCloud('terraform-api-token')
+const { Account, Plans, Runs } = new TerraformCloud('terraform-api-token')
 
 // Make an API call
 
@@ -51,16 +51,27 @@ Account.updatePassword(updatePasswordRequest).then(user => {
 Plans.show('plan-id').then(plan => {
   // handle plan data
 })
+
+// Runs
+
+Runs.show('run-id').then(run => {
+  // handle run data
+})
+
+// Perform an action over a run ex: (apply, cancel, discard, force-cancel, force-execute)
+Runs.action('cancel', 'run-id', { data: { comment: 'cancel run by id' } }).then(() => {
+  // handle run action
+})
 ```
 
 ## Current implementation
 
 - [x] [Account](https://www.terraform.io/docs/cloud/api/account.html) (100%)
+- [x] [Runs](https://www.terraform.io/docs/cloud/api/plans.html) (100%)
 - [x] [Plans](https://www.terraform.io/docs/cloud/api/plans.html) (90%) - **TODO:** Plan Json Output
 
 ## TODO
 
-- [ ] Runs
 - [ ] Workspaces
 - [ ] ...
 

--- a/src/api/TerraformCloud.ts
+++ b/src/api/TerraformCloud.ts
@@ -1,10 +1,10 @@
 import { EventEmitter } from 'events'
 import terraformCloudApiClient from './terraformCloudApiClient'
-import Account from './Account'
-import Plans from './Plans'
-import Runs from './Runs'
+import Account from './endpoints/Account'
+import Plans from './endpoints/Plans'
+import Runs from './endpoints/Runs'
 
-export default class TerraformCloud extends EventEmitter {
+export class TerraformCloud extends EventEmitter {
   public Account: Account
   public Plans: Plans
   public Runs: Runs

--- a/src/api/endpoints/Account.ts
+++ b/src/api/endpoints/Account.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios'
-import { User, UserPassword, UserUpdateInfo } from '../types/User'
-import { Request } from './Request'
+import { User, UserUpdatePassword, UserUpdateInfo } from '../..'
+import Request from './Request'
 
 export default class Account extends Request {
   constructor(client: AxiosInstance) {
@@ -22,8 +22,8 @@ export default class Account extends Request {
     return await this.patch<User, UserUpdateInfo>(path, request)
   }
 
-  async changePassword(request: UserPassword): Promise<User> {
+  async changePassword(request: UserUpdatePassword): Promise<User> {
     const path = '/account/password'
-    return await this.patch<User, UserPassword>(path, request)
+    return await this.patch<User, UserUpdatePassword>(path, request)
   }
 }

--- a/src/api/endpoints/Plans.ts
+++ b/src/api/endpoints/Plans.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios'
-import { Plan } from '../types'
-import { Request } from './Request'
+import { Plan } from '../..'
+import Request from './Request'
 
 export default class Plans extends Request {
   constructor(client: AxiosInstance) {

--- a/src/api/endpoints/Request.ts
+++ b/src/api/endpoints/Request.ts
@@ -1,6 +1,6 @@
 import { AxiosInstance } from 'axios'
 
-export abstract class Request {
+export default abstract class Request {
   constructor(private client: AxiosInstance) {}
   protected async get<T>(path: string): Promise<T> {
     const response = await this.client.get<T>(path)

--- a/src/api/endpoints/Runs.ts
+++ b/src/api/endpoints/Runs.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance } from 'axios'
-import { Run } from '..'
-import { Request } from './Request'
-import { RunRequest, RunActionRequest, RunAction } from '../types/Run'
+import { Run } from '../..'
+import Request from './Request'
+import { RunRequest, RunActionRequest, RunAction } from '../../types/Run'
 
 export default class Runs extends Request {
   constructor(client: AxiosInstance) {
@@ -25,6 +25,6 @@ export default class Runs extends Request {
 
   async action(action: RunAction, runId: string, request?: RunActionRequest): Promise<void> {
     const path = `/runs/${runId}/actions/${action}`
-    return await this.post<void, RunActionRequest>(path, request ? request : {})
+    return await this.post<void, RunActionRequest>(path, request || {})
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-import TerraformCloud from './api/TerraformCloud'
-import { User, Plan, Run } from './types'
+import { TerraformCloud } from './api/TerraformCloud'
 
-export { TerraformCloud, User, Plan, Run }
+export * from './types/Plan'
+export * from './types/Run'
+export * from './types/TerraformCloudData'
+export * from './types/User'
+
+export default TerraformCloud

--- a/src/types/Plan.ts
+++ b/src/types/Plan.ts
@@ -4,11 +4,11 @@ export type Plan = TerraformCloudData<PlanAttributes> & {
   relationships: PlanRelationship
 }
 
-interface PlanRelationship {
+export interface PlanRelationship {
   stateVersions: Relationship
 }
 
-interface PlanAttributes {
+export interface PlanAttributes {
   hasChanges: boolean
   logReadUrl: string
   resourceAdditions: number
@@ -18,7 +18,7 @@ interface PlanAttributes {
   statusTimestamps: PlanTimestamps
 }
 
-interface PlanTimestamps {
+export interface PlanTimestamps {
   finishedAt: Date
   pendingAt: Date
   queuedAt: Date

--- a/src/types/Run.ts
+++ b/src/types/Run.ts
@@ -1,4 +1,4 @@
-import { TerraformCloudData, Relationship, Type } from './TerraformCloudData'
+import { TerraformCloudData, Relationship } from './TerraformCloudData'
 
 export type Run = TerraformCloudData<RunAttributes> & {
   relationships: RunRelationship
@@ -21,26 +21,26 @@ export type RunRequest = {
       workspace: {
         data: {
           id: string
-          type: Type.Workspaces
+          type: 'workspaces'
         }
       }
       'configuration-version': {
         data: {
           id: string
-          type: Type.ConfigurationVersions
+          type: 'configuration-versions'
         }
       }
     }
   }
 }
 
-interface RunRelationship {
+export interface RunRelationship {
   confirmedBy: Relationship
   createdBy: Relationship
   plan: Relationship
 }
 
-interface RunAttributes {
+export interface RunAttributes {
   autoApply: boolean
   createdAt: Date
   errorText: null | string

--- a/src/types/TerraformCloudData.ts
+++ b/src/types/TerraformCloudData.ts
@@ -1,4 +1,4 @@
-interface Data {
+export interface Data {
   id: string
   type: string
 }
@@ -18,14 +18,6 @@ export type TerraformCloudData<Attributes> = Data & {
   attributes: Attributes
   relationships?: [Relationship]
   links?: Links
-}
-
-export enum Type {
-  ConfigurationVersions = 'configuration-versions',
-  Plans = 'plans',
-  Runs = 'runs',
-  User = 'user',
-  Workspaces = 'workspaces',
 }
 
 export type Page = {

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,6 +1,6 @@
-import { TerraformCloudData, Links, Params, Type } from './TerraformCloudData'
+import { TerraformCloudData, Links, Params } from './TerraformCloudData'
 
-interface UserAttributes {
+export interface UserAttributes {
   avatarUrl: string
   email: string
   enterpriseSupport: boolean
@@ -21,25 +21,25 @@ interface UserAttributes {
   v2Only: boolean
 }
 
-interface UserPermissions {
+export interface UserPermissions {
   canChangeEmail: boolean
   canChangeUsername: boolean
   canCreateOrganizations: boolean
   canManageUserTokens: boolean
 }
 
-interface UserRelationships {
+export interface UserRelationships {
   authenticationTokens: {
     links: Links
   }
 }
 
-interface UpdateAttributes {
+export interface UpdateAttributes {
   email: string
   username: string
 }
 
-interface PasswordAttributes {
+export interface PasswordAttributes {
   current_password: string
   password: string
   password_confirmation: string
@@ -48,5 +48,5 @@ interface PasswordAttributes {
 export type User = TerraformCloudData<UserAttributes> & {
   relationships: UserRelationships
 }
-export type UserUpdateInfo = Params<Type.User, UpdateAttributes>
-export type UserPassword = Params<Type.User, PasswordAttributes>
+export type UserUpdateInfo = Params<'users', UpdateAttributes>
+export type UserUpdatePassword = Params<'users', PasswordAttributes>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,4 @@
-import { User } from './User'
-import { Plan } from './Plan'
-import { Run } from './Run'
-
-export { User, Plan, Run }
+export * from './User'
+export * from './Plan'
+export * from './Run'
+export * from './TerraformCloudData'

--- a/test/api/Account.spec.ts
+++ b/test/api/Account.spec.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import TerraformCloud from '../../src/api/TerraformCloud'
+import TerraformCloud from '../../src/'
 import { UserDetailsUpdateMock, UserMock, UserPasswordUpdateMock } from '../mocks'
 
 const { Account } = new TerraformCloud('api-key')

--- a/test/api/Plans.spec.ts
+++ b/test/api/Plans.spec.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import TerraformCloud from '../../src/api/TerraformCloud'
+import TerraformCloud from '../../src'
 import { PlanMock } from '../mocks'
 
 const { Plans } = new TerraformCloud('api-key')

--- a/test/api/Runs.spec.ts
+++ b/test/api/Runs.spec.ts
@@ -1,7 +1,5 @@
 import nock from 'nock'
-import TerraformCloud from '../../src/api/TerraformCloud'
-import { RunAction } from '../../src/types/Run'
-import { Type } from '../../src/types/TerraformCloudData'
+import TerraformCloud, { RunAction, RunActionRequest } from '../../src'
 import { RunMock, RunRequestMock } from '../mocks'
 
 const { Runs } = new TerraformCloud('api-key')
@@ -10,7 +8,7 @@ const workspaceId = 'workspace-id'
 const actions: RunAction[] = ['apply', 'discard', 'cancel', 'force-cancel', 'force-execute']
 
 describe('Runs endpoints', () => {
-  it('creates a run', async done => {
+  it('create run', async done => {
     const scope = nock('https://app.terraform.io/api/v2').post(`/runs`, RunRequestMock).reply(201, { data: RunMock })
     const run = await Runs.create(RunRequestMock)
 
@@ -19,11 +17,11 @@ describe('Runs endpoints', () => {
     done()
   })
 
-  it('show a run by id', async done => {
+  it('show run by id', async done => {
     const scope = nock('https://app.terraform.io/api/v2').get(`/runs/${runId}`).reply(200, { data: RunMock })
 
     const run = await Runs.show(runId)
-    expect(run.type).toBe(Type.Runs)
+    expect(run.type).toBe('runs')
     scope.done()
     done()
   })
@@ -43,10 +41,9 @@ describe('Runs endpoints', () => {
 
   actions.map(action => {
     it(`run action ${action}`, async done => {
-      const scope = nock('https://app.terraform.io/api/v2')
-        .post(`/runs/${runId}/actions/${action}`, { comment: 'none' })
-        .reply(204)
-      await Runs.action(action, runId, { comment: 'none' })
+      const request: RunActionRequest = { comment: 'none' }
+      const scope = nock('https://app.terraform.io/api/v2').post(`/runs/${runId}/actions/${action}`, request).reply(204)
+      await Runs.action(action, runId, request)
       scope.done()
       done()
     })

--- a/test/mocks/RunMock.ts
+++ b/test/mocks/RunMock.ts
@@ -53,14 +53,13 @@ export const RunMock = {
   links: { self: '/api/v2/runs/run-ybWY3ADtDx4YNaph' },
 }
 
-export const RunRequestMock = {
+export const RunRequestMock: RunRequest = {
   data: {
     attributes: {
       'is-destroy': false,
       message: 'Custom message',
       'target-addrs': ['example.resource_address'],
     },
-    type: 'runs',
     relationships: {
       workspace: {
         data: {
@@ -76,4 +75,4 @@ export const RunRequestMock = {
       },
     },
   },
-} as RunRequest
+}

--- a/test/mocks/UserMock.ts
+++ b/test/mocks/UserMock.ts
@@ -1,5 +1,4 @@
-import { Type } from '../../src/types/TerraformCloudData'
-import { UserPassword, UserUpdateInfo } from '../../src/types/User'
+import { UserUpdateInfo, UserUpdatePassword } from '../../src'
 
 export const UserMock = {
   data: {
@@ -32,23 +31,23 @@ export const UserMock = {
   },
 }
 
-export const UserPasswordUpdateMock = {
+export const UserPasswordUpdateMock: UserUpdatePassword = {
   data: {
-    type: Type.User,
+    type: 'users',
     attributes: {
       current_password: 'current-password',
       password: 'new-password',
       password_confirmation: 'new-password',
     },
   },
-} as UserPassword
+}
 
-export const UserDetailsUpdateMock = {
+export const UserDetailsUpdateMock: UserUpdateInfo = {
   data: {
-    type: Type.User,
+    type: 'users',
     attributes: {
       email: 'user@example.com',
       username: 'username',
     },
   },
-} as UserUpdateInfo
+}

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -1,5 +1,3 @@
-import { PlanMock } from './PlanMock'
-import { RunMock, RunRequestMock } from './RunMock'
-import { UserDetailsUpdateMock, UserMock, UserPasswordUpdateMock } from './UserMock'
-
-export { PlanMock, RunMock, RunRequestMock, UserDetailsUpdateMock, UserMock, UserPasswordUpdateMock }
+export * from './PlanMock'
+export * from './RunMock'
+export * from './UserMock'


### PR DESCRIPTION
## Why? What?

- Refactor folder structure
- Export all types
- move endpoints definitions to api/endpoints
